### PR TITLE
Bugfixes

### DIFF
--- a/include/wila/utils.hpp
+++ b/include/wila/utils.hpp
@@ -173,6 +173,12 @@ namespace mhcpp
 		}
 
 		template<typename K = string, typename V = string>
+		bool HasKey(const std::map<K, V>& dict, const string& key)
+		{
+			return (dict.find(key) != dict.end());
+		}
+
+		template<typename K = string, typename V = string>
 		std::map<K, V> Subset(const std::vector<K>& keys, const std::map<K, V>& dict, bool allowMissing = false)
 		{
 			std::map<K, V> result;
@@ -184,12 +190,6 @@ namespace mhcpp
 					result.emplace(k, V(dict.at(k)));
 			}
 			return result;
-		}
-
-		template<typename K = string, typename V = string>
-		bool HasKey(const std::map<K, V>& dict, const string& key)
-		{
-			return (dict.find(key) != dict.end());
 		}
 
 		template<typename K, typename V>

--- a/include/wila/utils.hpp
+++ b/include/wila/utils.hpp
@@ -35,6 +35,9 @@ using namespace Concurrency;
 using namespace tbb;
 #endif
 
+#ifdef _WIN32
+	_set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
 
 using namespace std;
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -37,13 +37,13 @@ using namespace mhcpp::optimization;
 using namespace mhcpp::utils;
 
 TEST_CASE("Number formating is scientific by default", "[utils]") {
-	REQUIRE(ToString(1.23456789) == "1.234568e+000");
-	REQUIRE(ToString(1.23456711) == "1.234567e+000");
-	REQUIRE(ToString(1.23) == "1.230000e+000");
-	REQUIRE(ToString(12.3456789) == "1.234568e+001");
-	REQUIRE(ToString(1.23456789e33) == "1.234568e+033");
-	REQUIRE(ToString(1.23456789e-33) == "1.234568e-033");
-	REQUIRE(ToString(-1.23456789e-33) == "-1.234568e-033");
+	REQUIRE(ToString(1.23456789) == "1.234568e+00");
+	REQUIRE(ToString(1.23456711) == "1.234567e+00");
+	REQUIRE(ToString(1.23) == "1.230000e+00");
+	REQUIRE(ToString(12.3456789) == "1.234568e+01");
+	REQUIRE(ToString(1.23456789e33) == "1.234568e+33");
+	REQUIRE(ToString(1.23456789e-33) == "1.234568e-33");
+	REQUIRE(ToString(-1.23456789e-33) == "-1.234568e-33");
 
 	REQUIRE(ToString(123456789) == "123456789");
 	REQUIRE(ToString(123456789123456789ul) == "123456789123456789");


### PR DESCRIPTION
Two bug fixes:
* Fix 'HasKey' scope lookup by changing ordering; Resolves build error: "./include/wila/utils.hpp:181:24: error: ‘HasKey’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]"
* Consistent two digit exponent on Windows and Linux.

Regarding the exponent change, by default Windows will do scientific string exponents as 3 digits while Linux produces two digit exponents. As far as I can tell the tests are checking that scientific strings are printed and the three digit exponent specifically isn't important where it isn't significant (e.g. +000 vs +00). Hence this change to make the behaviour consistent between Windows and Linux.