### PR TITLE
Remove ifdef for setting TWO_DIGIT_EXPONENT on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This software is released under the LGPL v3. See LICENSE.
 This is written in C++ using some features from the C++11 standard. It is known to compile with:
 
 * GCC version 4.8 or above
-* Visual C++ as from Visual Studio 2013 update 5, or above.
+* Visual C++ as from Visual Studio 2015, or above.
 
 # Getting started
 

--- a/include/wila/utils.hpp
+++ b/include/wila/utils.hpp
@@ -35,10 +35,6 @@ using namespace Concurrency;
 using namespace tbb;
 #endif
 
-#ifdef _WIN32
-	//_set_output_format(_TWO_DIGIT_EXPONENT);
-#endif
-
 using namespace std;
 
 namespace mhcpp


### PR DESCRIPTION
This change was originally added to get standard two digit exponent
behaviour on Windows and Linux. However the proprietary feature was
removed with Visual Studio 2015 and the standards conforming behaviour
was made default.

Therefore for passing tests Visual Studio 2015 or greater is required,
so updated the README to reflect the dependency on newer Visual Studio.

"Exponent formatting: The %e and %E format specifiers format a floating
point number as a decimal mantissa and exponent. The %g and %G format
specifiers also format numbers in this form in some cases. In previous
versions, the CRT would always generate strings with three-digit
exponents. For example, printf("%e\n", 1.0) would print 1.000000e+000.
This was incorrect: C requires that if the exponent is representable
using only one or two digits, then only two digits are to be printed.

In Visual Studio 2005 a global conformance switch was added:
_set_output_format. A program could call this function with the argument
_TWO_DIGIT_EXPONENT, to enable conforming exponent printing. The default
behavior has been changed to the standards-conforming exponent printing
mode." - https://msdn.microsoft.com/en-us/library/bb531344(v=vs.140).aspx